### PR TITLE
Migrate from dio+retrofit to chopper and update environment configuration

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,3 @@
+ENVIRONMENT=dev
+API_BASE_URL=https://kyouen-server-dev-732262258565.asia-northeast1.run.app/v2/
+FIREBASE_PROJECT_ID=api-project-732262258565

--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,3 @@
+ENVIRONMENT=prod
+API_BASE_URL=https://kyouen.app/v2/
+FIREBASE_PROJECT_ID=my-android-server

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,20 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "kyouen-flutter",
+            "name": "app (dev)",
             "request": "launch",
-            "type": "dart"
+            "type": "dart",
+            "toolArgs": [
+                "--dart-define-from-file=.env.dev"
+            ]
+        },
+        {
+            "name": "app (prod)",
+            "request": "launch",
+            "type": "dart",
+            "toolArgs": [
+                "--dart-define-from-file=.env.prod"
+            ]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ This app supports environment switching using `dart-define` to configure:
 
 ### Environment Variables
 
+The application uses environment variables configured via `--dart-define-from-file` using `.env` files:
+
+- `.env.dev`: Development environment configuration
+- `.env.prod`: Production environment configuration
+
+Environment variables:
 - `ENVIRONMENT`: Set to `dev` or `prod` (default: `prod`)
 - `API_BASE_URL`: API endpoint URL (default: `https://kyouen.app/v2/`)
 - `FIREBASE_PROJECT_ID`: Firebase project ID (default: `my-android-server`)
@@ -60,9 +66,7 @@ Each script automatically runs the appropriate `flutterfire configure` command t
 
 # Or manually
 flutter run \
-  --dart-define=ENVIRONMENT=dev \
-  --dart-define=API_BASE_URL=https://dev.kyouen.app/v2/ \
-  --dart-define=FIREBASE_PROJECT_ID=api-project-732262258565
+  --dart-define-from-file=.env.dev
 ```
 
 #### Production Environment
@@ -72,9 +76,7 @@ flutter run \
 
 # Or manually
 flutter run \
-  --dart-define=ENVIRONMENT=prod \
-  --dart-define=API_BASE_URL=https://kyouen.app/v2/ \
-  --dart-define=FIREBASE_PROJECT_ID=my-android-server
+  --dart-define-from-file=.env.prod
 ```
 
 ### Building for Different Environments

--- a/lib/src/config/environment.dart
+++ b/lib/src/config/environment.dart
@@ -4,7 +4,7 @@ class Environment {
 
   /// API base URL
   /// Default: https://kyouen.app/v2/
-  /// Dev: https://dev.kyouen.app/v2/ (example)
+  /// Dev: https://kyouen-server-dev-732262258565.asia-northeast1.run.app/v2/ (example)
   static const apiBaseUrl = String.fromEnvironment(
     'API_BASE_URL',
     defaultValue: 'https://kyouen.app/v2/',

--- a/lib/src/data/api/api_client.dart
+++ b/lib/src/data/api/api_client.dart
@@ -1,6 +1,8 @@
 import 'package:chopper/chopper.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kyouen_flutter/src/config/environment.dart';
+import 'package:kyouen_flutter/src/data/api/entity/login_request.dart';
+import 'package:kyouen_flutter/src/data/api/entity/login_response.dart';
 import 'package:kyouen_flutter/src/data/api/entity/stage_response.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -16,6 +18,9 @@ abstract class ApiClient extends ChopperService {
   Future<Response<List<StageResponse>>> getStages({
     @Query('start_stage_no') int startStageNo = 1,
   });
+
+  @POST(path: '/users/login')
+  Future<Response<LoginResponse>> login(@Body() LoginRequest request);
 }
 
 @riverpod

--- a/lib/src/data/api/api_client.dart
+++ b/lib/src/data/api/api_client.dart
@@ -1,9 +1,13 @@
+import 'dart:developer' as developer;
+
 import 'package:chopper/chopper.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kyouen_flutter/src/config/environment.dart';
 import 'package:kyouen_flutter/src/data/api/entity/login_request.dart';
 import 'package:kyouen_flutter/src/data/api/entity/login_response.dart';
 import 'package:kyouen_flutter/src/data/api/entity/stage_response.dart';
+import 'package:kyouen_flutter/src/data/api/json_serializable_converter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'api_client.chopper.dart';
@@ -11,8 +15,7 @@ part 'api_client.g.dart';
 
 @ChopperApi(baseUrl: '/')
 abstract class ApiClient extends ChopperService {
-  static ApiClient create([ChopperClient? client]) =>
-      _$ApiClient(client);
+  static ApiClient create([ChopperClient? client]) => _$ApiClient(client);
 
   @GET(path: '/stages')
   Future<Response<List<StageResponse>>> getStages({
@@ -27,13 +30,9 @@ abstract class ApiClient extends ChopperService {
 ApiClient apiClient(Ref ref) {
   final client = ChopperClient(
     baseUrl: Uri.parse(Environment.apiBaseUrl),
-    services: [
-      ApiClient.create(),
-    ],
-    converter: const JsonConverter(),
-    interceptors: [
-      HttpLoggingInterceptor(),
-    ],
+    services: [ApiClient.create()],
+    converter: JsonSerializableConverter(),
+    interceptors: [if (kDebugMode) HttpLoggingInterceptor()],
   );
   return ApiClient.create(client);
 }

--- a/lib/src/data/api/entity/login_request.dart
+++ b/lib/src/data/api/entity/login_request.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'login_request.freezed.dart';
+part 'login_request.g.dart';
+
+@freezed
+abstract class LoginRequest with _$LoginRequest {
+  const factory LoginRequest({
+    required String token,
+  }) = _LoginRequest;
+
+  factory LoginRequest.fromJson(Map<String, Object?> json) =>
+      _$LoginRequestFromJson(json);
+}

--- a/lib/src/data/api/entity/login_response.dart
+++ b/lib/src/data/api/entity/login_response.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'login_response.freezed.dart';
+part 'login_response.g.dart';
+
+@freezed
+abstract class LoginResponse with _$LoginResponse {
+  const factory LoginResponse({
+    required String screenName,
+  }) = _LoginResponse;
+
+  factory LoginResponse.fromJson(Map<String, Object?> json) =>
+      _$LoginResponseFromJson(json);
+}

--- a/lib/src/data/api/json_serializable_converter.dart
+++ b/lib/src/data/api/json_serializable_converter.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
+import 'package:kyouen_flutter/src/data/api/entity/login_response.dart';
+import 'package:kyouen_flutter/src/data/api/entity/stage_response.dart';
+
+class JsonSerializableConverter extends JsonConverter {
+  @override
+  Response<BodyType> convertResponse<BodyType, InnerType>(Response<dynamic> response) {
+    return response.copyWith<BodyType>(
+      body: fromJsonData<BodyType, InnerType>(
+        response.body as String,
+        response.base.request!.url.path,
+      ),
+    );
+  }
+
+  T fromJsonData<T, InnerType>(String jsonData, String url) {
+    final jsonMap = jsonDecode(jsonData);
+
+    if (jsonMap is List) {
+      return _convertList<T, InnerType>(jsonMap);
+    } else if (jsonMap is Map<String, dynamic>) {
+      return _convertSingle<T>(jsonMap, url);
+    }
+
+    return jsonMap as T;
+  }
+
+  T _convertList<T, InnerType>(List<dynamic> jsonList) {
+    if (InnerType == StageResponse) {
+      return jsonList
+          .map((item) => StageResponse.fromJson(item as Map<String, dynamic>))
+          .toList() as T;
+    }
+
+    return jsonList as T;
+  }
+
+  T _convertSingle<T>(Map<String, dynamic> jsonMap, String url) {
+    if (T == LoginResponse || url.contains('/users/login')) {
+      return LoginResponse.fromJson(jsonMap) as T;
+    } else if (T == StageResponse || url.contains('/stages')) {
+      return StageResponse.fromJson(jsonMap) as T;
+    }
+
+    return jsonMap as T;
+  }
+}

--- a/scripts/build_dev.sh
+++ b/scripts/build_dev.sh
@@ -13,11 +13,9 @@ flutterfire configure \
   --yes
 
 flutter build web \
-  --dart-define=ENVIRONMENT=dev \
-  --dart-define=API_BASE_URL=https://dev.kyouen.app/v2/ \
-  --dart-define=FIREBASE_PROJECT_ID=api-project-732262258565
+  --dart-define-from-file=.env.dev
 
 echo "Development build completed!"
 echo "App name will show as: 'DEV 詰め共円'"
-echo "API will connect to: https://dev.kyouen.app/v2/"
+echo "API will connect to: https://kyouen-server-dev-732262258565.asia-northeast1.run.app/v2/"
 echo "Firebase project: api-project-732262258565"

--- a/scripts/build_prod.sh
+++ b/scripts/build_prod.sh
@@ -13,9 +13,7 @@ flutterfire configure \
   --yes
 
 flutter build web \
-  --dart-define=ENVIRONMENT=prod \
-  --dart-define=API_BASE_URL=https://kyouen.app/v2/ \
-  --dart-define=FIREBASE_PROJECT_ID=my-android-server
+  --dart-define-from-file=.env.prod
 
 echo "Production build completed!"
 echo "App name will show as: '詰め共円'"

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -13,11 +13,9 @@ flutterfire configure \
   --yes
 
 flutter run \
-  --dart-define=ENVIRONMENT=dev \
-  --dart-define=API_BASE_URL=https://dev.kyouen.app/v2/ \
-  --dart-define=FIREBASE_PROJECT_ID=api-project-732262258565
+  --dart-define-from-file=.env.dev
 
 echo "Development app is running!"
 echo "App name will show as: 'DEV 詰め共円'"
-echo "API will connect to: https://dev.kyouen.app/v2/"
+echo "API will connect to: https://kyouen-server-dev-732262258565.asia-northeast1.run.app/v2/"
 echo "Firebase project: api-project-732262258565"

--- a/scripts/run_prod.sh
+++ b/scripts/run_prod.sh
@@ -13,9 +13,7 @@ flutterfire configure \
   --yes
 
 flutter run \
-  --dart-define=ENVIRONMENT=prod \
-  --dart-define=API_BASE_URL=https://kyouen.app/v2/ \
-  --dart-define=FIREBASE_PROJECT_ID=my-android-server
+  --dart-define-from-file=.env.prod
 
 echo "Production app is running!"
 echo "App name will show as: '詰め共円'"

--- a/scripts/test_dev.sh
+++ b/scripts/test_dev.sh
@@ -4,8 +4,6 @@
 echo "Running tests with development environment configuration..."
 
 flutter test test/environment_test.dart \
-  --dart-define=ENVIRONMENT=dev \
-  --dart-define=API_BASE_URL=https://dev.kyouen.app/v2/ \
-  --dart-define=FIREBASE_PROJECT_ID=api-project-732262258565
+  --dart-define-from-file=.env.dev
 
 echo "Development environment tests completed!"


### PR DESCRIPTION
## Summary
- Migrate API client from dio+retrofit to chopper for better maintainability
- Update environment configuration to use --dart-define-from-file with .env files
- Add login API integration with error handling
- Update DEV environment domain to new Google Cloud Run endpoint
- Add detailed API logging for debugging

## Changes Made

### API Client Migration
- Replace dio+retrofit with chopper for HTTP client
- Create custom JsonSerializableConverter for proper JSON deserialization
- Add login API endpoint with LoginRequest/LoginResponse entities
- Enhance API logging with debug-only interceptors

### Environment Configuration
- Create .env.dev and .env.prod files for environment-specific settings
- Update all build/run scripts to use --dart-define-from-file
- Update DEV domain to kyouen-server-dev-732262258565.asia-northeast1.run.app
- Add VS Code launch configurations for dev/prod environments

### Authentication Integration
- Add Firebase authentication integration in sign-in page
- Call backend login API after successful social login
- Add proper error handling for authentication flows

## Test plan
- [ ] Test development environment build and run scripts
- [ ] Test production environment build and run scripts
- [ ] Verify API client works with new chopper implementation
- [ ] Test Firebase authentication and backend API integration
- [ ] Verify VS Code debug configurations work properly

🤖 Generated with [Claude Code](https://claude.ai/code)