### PR TITLE
Fix flutterfire command not found error by installing CLI tools

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -28,6 +28,14 @@ jobs:
           flutter-version: '3.32.4'
           channel: 'stable'
       
+      - name: Install Firebase CLI
+        run: |
+          curl -sL https://firebase.tools | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      
+      - name: Install FlutterFire CLI
+        run: dart pub global activate flutterfire_cli
+      
       - name: Get dependencies
         run: flutter pub get
       


### PR DESCRIPTION
## Summary
- Fix "flutterfire: command not found" error in GitHub Actions workflow
- Add Firebase CLI and FlutterFire CLI installation to prepare job
- Update PATH configuration for Firebase CLI accessibility

## Changes
- Add Firebase CLI installation via official installer script
- Add FlutterFire CLI installation via dart pub global activate
- Configure PATH to include Firebase CLI binary location

## Test plan
- [x] Verify Firebase CLI installation step works correctly
- [x] Verify FlutterFire CLI installation step works correctly
- [x] Confirm flutterfire configure command executes without errors
- [x] Test workflow execution with both dev and prod environments

🤖 Generated with [Claude Code](https://claude.ai/code)