### PR TITLE
Fix Firebase CLI authentication error with service account credentials

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Install FlutterFire CLI
         run: dart pub global activate flutterfire_cli
       
+      - name: Setup Firebase Authentication
+        env:
+          FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+        run: |
+          echo "$FIREBASE_SERVICE_ACCOUNT_KEY" > $RUNNER_TEMP/firebase-service-account.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-service-account.json" >> $GITHUB_ENV
+      
       - name: Get dependencies
         run: flutter pub get
       


### PR DESCRIPTION
## Summary
- Fix Firebase CLI authentication error in GitHub Actions workflow
- Add proper service account credential setup for Firebase operations
- Resolve "Failed to authenticate, have you run firebase login?" error

## Changes
- Add Firebase authentication step using `FIREBASE_SERVICE_ACCOUNT_KEY` secret
- Set `GOOGLE_APPLICATION_CREDENTIALS` environment variable for Firebase CLI
- Store service account JSON securely in runner temp directory
- Enable `flutterfire configure` command to access Firebase projects

## Root Cause
The Firebase CLI requires authentication to access Firebase projects. Without proper credentials, the `flutterfire configure` command fails with authentication errors.

## Solution
Instead of using interactive login (not possible in CI), we use service account credentials:
1. Store service account JSON from secrets in secure temp location
2. Set `GOOGLE_APPLICATION_CREDENTIALS` environment variable
3. Firebase CLI automatically uses these credentials for authentication

## Test plan
- [x] Verify service account credentials are properly configured
- [x] Confirm Firebase CLI can authenticate without interactive login
- [x] Test `flutterfire configure` command executes successfully
- [x] Validate workflow runs without authentication errors

🤖 Generated with [Claude Code](https://claude.ai/code)