### PR TITLE
Update build tools and dependencies for Android/iOS compatibility

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -131,9 +131,9 @@ jobs:
       - name: Build iOS IPA
         run: |
           if [ "${{ github.event.inputs.environment }}" = "dev" ]; then
-            flutter build ipa --dart-define-from-file=.env.dev --release
+            flutter build ipa --dart-define-from-file=.env.dev --release --verbose
           else
-            flutter build ipa --dart-define-from-file=.env.prod --release
+            flutter build ipa --dart-define-from-file=.env.prod --release --verbose
           fi
       
       - name: Upload iOS artifact
@@ -185,9 +185,9 @@ jobs:
       - name: Build Android APK
         run: |
           if [ "${{ github.event.inputs.environment }}" = "dev" ]; then
-            flutter build apk --dart-define-from-file=.env.dev --release
+            flutter build apk --dart-define-from-file=.env.dev --release --verbose
           else
-            flutter build apk --dart-define-from-file=.env.prod --release
+            flutter build apk --dart-define-from-file=.env.prod --release --verbose
           fi
       
       - name: Build Android AAB

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.11.0'
         // START: FlutterFire Configuration
         classpath 'com.google.gms:google-services:4.4.2'
         classpath 'com.google.firebase:perf-plugin:1.4.2'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx2048M
 android.useAndroidX=true
 android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1510"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Extract Dart Defines"
-               scriptText = "&quot;${SRCROOT}/scripts/extract_dart_defines.sh&quot;">
+               scriptText = "&quot;${SRCROOT}/scripts/extract_dart_defines.sh&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
## Summary
- Update Android Gradle Plugin from 8.7.3 to 8.11.0 for latest features and bug fixes
- Increase Gradle JVM heap size from 1536M to 2048M to improve build performance
- Upgrade Gradle wrapper from 8.11.1 to 8.13 for latest tooling support
- Update Xcode scheme version from 1.3 to 1.7 for iOS compatibility
- Fix script formatting in iOS scheme configuration

## Test plan
- [ ] Verify Android build completes successfully with new Gradle versions
- [ ] Test iOS build with updated Xcode scheme configuration
- [ ] Confirm build performance improvements with increased heap size
- [ ] Run CI/CD pipeline to validate cross-platform compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)