### PR TITLE
fix: App Store Connect API環境変数の修正

### DIFF
--- a/.github/scripts/prepare_release.js
+++ b/.github/scripts/prepare_release.js
@@ -48,6 +48,27 @@ function createAPIClient() {
 
 async function main() {
   try {
+    // Validate required environment variables
+    const requiredEnvVars = {
+      'VERSION_NAME': VERSION_NAME,
+      'APPLE_KEY_ID': API_KEY_ID,
+      'APPLE_ISSUER_ID': ISSUER_ID,
+      'P8_APPSTORECONNECT_API': PRIVATE_KEY
+    };
+
+    const missingVars = [];
+    for (const [name, value] of Object.entries(requiredEnvVars)) {
+      if (!value) {
+        missingVars.push(name);
+      }
+    }
+
+    if (missingVars.length > 0) {
+      throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`);
+    }
+
+    console.log('Environment variables validation passed');
+
     const api = createAPIClient();
 
     console.log(`Starting preparation for version ${VERSION_NAME}`);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -29,6 +29,9 @@ jobs:
         working-directory: .github/scripts
         env:
           VERSION_NAME: ${{ github.event.inputs.version_name }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          P8_APPSTORECONNECT_API: ${{ secrets.P8_APPSTORECONNECT_API }}
         run: node prepare_release.js
 
       - name: Summary (Success)


### PR DESCRIPTION
## 概要
GitHub Actionsの  ワークフローで発生していた「secretOrPrivateKey must have a value」エラーを修正しました。

## 変更内容

### 1. prepare_release.js の改善
- 必要な環境変数の検証ロジックを追加
- 環境変数が不足している場合の明確なエラーメッセージを表示

### 2. prepare-release.yml の改善  
- App Store Connect API に必要な環境変数を追加:
  - `APPLE_KEY_ID`: App Store Connect API キー ID
  - `APPLE_ISSUER_ID`: App Store Connect API 発行者 ID
  - `P8_APPSTORECONNECT_API`: App Store Connect API 秘密鍵

## 修正されるエラー
- `secretOrPrivateKey must have a value` エラー
- JWT生成時のprivate key不足エラー

## 必要なアクション
このPRをマージした後、リポジトリの設定で以下のSecretsを追加してください：
- `APPLE_KEY_ID`
- `APPLE_ISSUER_ID`
- `P8_APPSTORECONNECT_API`

## テスト
環境変数の検証ロジックが正しく動作することを確認済みです。