### PR TITLE
Fix WidgetRef usage by removing parameter passing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ flutterfire configure \
 9. **クリア状況**: ステージクリア処理は `markCurrentStageCleared()` メソッドを使用
 10. **データベース変更**: SQLiteスキーマ変更時は `database.dart` の `_databaseVersion` を更新し、マイグレーション処理を追加
 11. **共通Widget**: 複数画面で使用するWidgetは `lib/src/widgets/common/` に配置し、一貫性のあるデザインを保つ
+12. **WidgetRef受け渡し禁止**: WidgetRefをコンストラクタ引数として他のWidgetに渡すことを禁止。代わりにConsumerWidgetまたはConsumerを使用してWidget内部でWidgetRefを取得する
 
 ## カスタムスラッシュコマンド
 

--- a/lib/src/features/sign_in/sign_in_page.dart
+++ b/lib/src/features/sign_in/sign_in_page.dart
@@ -18,7 +18,7 @@ class SignInPage extends ConsumerWidget {
         stream: FirebaseAuth.instance.authStateChanges(),
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
-            return _SignInView(ref: ref);
+            return const _SignInView();
           }
 
           return _LogoutView(user: snapshot.data!);
@@ -28,13 +28,11 @@ class SignInPage extends ConsumerWidget {
   }
 }
 
-class _SignInView extends StatelessWidget {
-  const _SignInView({required this.ref});
-
-  final WidgetRef ref;
+class _SignInView extends ConsumerWidget {
+  const _SignInView();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return BackgroundWidget(
       child: SafeArea(
         child: Padding(
@@ -54,10 +52,7 @@ class _SignInView extends StatelessWidget {
                     onPressed: () {
                       Navigator.pop(context);
                     },
-                    icon: const Icon(
-                      Icons.arrow_back,
-                      color: Colors.white,
-                    ),
+                    icon: const Icon(Icons.arrow_back, color: Colors.white),
                   ),
                 ),
               ),
@@ -78,15 +73,13 @@ class _SignInView extends StatelessWidget {
                 ),
                 child: Column(
                   children: [
-                    const Icon(
-                      Icons.login,
-                      size: 48,
-                      color: Color(0xFF4A90E2),
-                    ),
+                    const Icon(Icons.login, size: 48, color: Color(0xFF4A90E2)),
                     const SizedBox(height: 16),
                     Text(
                       'ログイン',
-                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      style: Theme.of(
+                        context,
+                      ).textTheme.headlineMedium?.copyWith(
                         color: const Color(0xFF2C3E50),
                         fontWeight: FontWeight.bold,
                       ),
@@ -117,7 +110,7 @@ class _SignInView extends StatelessWidget {
                   ],
                 ),
                 child: ElevatedButton(
-                  onPressed: _signInWithTwitter,
+                  onPressed: () => _signInWithTwitter(ref),
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color(0xFF1DA1F2), // Twitter blue
                     foregroundColor: Colors.white,
@@ -156,7 +149,7 @@ class _SignInView extends StatelessWidget {
                   ],
                 ),
                 child: ElevatedButton(
-                  onPressed: _signInWithApple,
+                  onPressed: () => _signInWithApple(ref),
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.black,
                     foregroundColor: Colors.white,
@@ -189,7 +182,7 @@ class _SignInView extends StatelessWidget {
     );
   }
 
-  Future<void> _signInWithTwitter() async {
+  Future<void> _signInWithTwitter(WidgetRef ref) async {
     await FirebaseAuth.instance.signOut();
     final twitterProvider = TwitterAuthProvider();
 
@@ -205,13 +198,13 @@ class _SignInView extends StatelessWidget {
         );
       }
 
-      await _callLoginApi(userCredential.user);
+      await _callLoginApi(userCredential.user, ref);
     } on Exception catch (e) {
       debugPrint('Twitter sign-in failed: $e');
     }
   }
 
-  Future<void> _signInWithApple() async {
+  Future<void> _signInWithApple(WidgetRef ref) async {
     final appleProvider = AppleAuthProvider();
 
     try {
@@ -226,13 +219,13 @@ class _SignInView extends StatelessWidget {
         );
       }
 
-      await _callLoginApi(userCredential.user);
+      await _callLoginApi(userCredential.user, ref);
     } on Exception catch (e) {
       debugPrint('Apple sign-in failed: $e');
     }
   }
 
-  Future<void> _callLoginApi(User? user) async {
+  Future<void> _callLoginApi(User? user, WidgetRef ref) async {
     if (user == null) {
       return;
     }
@@ -286,10 +279,7 @@ class _LogoutView extends StatelessWidget {
                     onPressed: () {
                       Navigator.pop(context);
                     },
-                    icon: const Icon(
-                      Icons.arrow_back,
-                      color: Colors.white,
-                    ),
+                    icon: const Icon(Icons.arrow_back, color: Colors.white),
                   ),
                 ),
               ),
@@ -318,7 +308,9 @@ class _LogoutView extends StatelessWidget {
                     const SizedBox(height: 16),
                     Text(
                       'ログイン済み',
-                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      style: Theme.of(
+                        context,
+                      ).textTheme.headlineMedium?.copyWith(
                         color: const Color(0xFF2C3E50),
                         fontWeight: FontWeight.bold,
                       ),


### PR DESCRIPTION
## Summary
- Convert _SignInView from StatelessWidget to ConsumerWidget to properly handle WidgetRef
- Remove anti-pattern of passing WidgetRef as constructor parameter
- Update method signatures to receive WidgetRef as parameter where needed
- Add coding rule to CLAUDE.md prohibiting WidgetRef parameter passing

## Test plan
- [x] Verify sign-in page compiles without errors
- [x] Ensure sign-in functionality works correctly
- [x] Confirm ConsumerWidget pattern is properly implemented
- [x] Validate that WidgetRef is accessible in all required methods

🤖 Generated with [Claude Code](https://claude.ai/code)