### PR TITLE
Implement stage persistence with SharedPreferences

### DIFF
--- a/lib/src/data/local/last_stage_service.dart
+++ b/lib/src/data/local/last_stage_service.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LastStageService {
+  static const _keyLastStageNo = 'last_stage_no';
+
+  Future<int?> getLastStageNo() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_keyLastStageNo);
+  }
+
+  Future<void> saveLastStageNo(int stageNo) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_keyLastStageNo, stageNo);
+  }
+}

--- a/lib/src/features/stage/stage_page.dart
+++ b/lib/src/features/stage/stage_page.dart
@@ -13,7 +13,6 @@ class StagePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // initialize and keep instance
-    // TODO: デフォルト値の設定
     ref.watch(currentStageNoProvider);
 
     return Scaffold(
@@ -36,9 +35,19 @@ class _Header extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentStage = ref.watch(currentStageProvider);
-    final currentStageNo = ref.watch(currentStageNoProvider);
+    final currentStageNoAsync = ref.watch(currentStageNoProvider);
     final clearedStages = ref.watch(clearedStageNumbersProvider);
     final isSmallScreen = MediaQuery.of(context).size.width < 600;
+
+    // Extract current stage number from AsyncValue
+    final currentStageNo = currentStageNoAsync.when(
+      data: (stageNo) => stageNo,
+      loading: () => null,
+      error: (_, _) => null,
+    );
+    if (currentStageNo == null) {
+      return const SizedBox.shrink(); // or some loading indicator
+    }
 
     // Check if current stage is cleared
     final isCleared = clearedStages.when(
@@ -54,8 +63,8 @@ class _Header extends ConsumerWidget {
           Expanded(
             flex: isSmallScreen ? 1 : 2,
             child: FilledButton(
-              onPressed: () {
-                ref.read(currentStageNoProvider.notifier).prev();
+              onPressed: () async {
+                await ref.read(currentStageNoProvider.notifier).prev();
               },
               child: Text(isSmallScreen ? '前' : '前へ'),
             ),
@@ -91,8 +100,8 @@ class _Header extends ConsumerWidget {
           Expanded(
             flex: isSmallScreen ? 1 : 2,
             child: FilledButton(
-              onPressed: () {
-                ref.read(currentStageNoProvider.notifier).next();
+              onPressed: () async {
+                await ref.read(currentStageNoProvider.notifier).next();
               },
               child: Text(isSmallScreen ? '次' : '次へ'),
             ),
@@ -134,7 +143,7 @@ class _Footer extends ConsumerWidget {
                     if (context.mounted) {
                       await _showKyouenDialog(context);
                     }
-                    ref.read(currentStageNoProvider.notifier).next();
+                    await ref.read(currentStageNoProvider.notifier).next();
                   } else {
                     debugPrint('NOT KYOUEN!');
                     if (context.mounted) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -685,6 +685,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   pedantic_mono:
     dependency: "direct dev"
     description:
@@ -821,6 +845,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.10"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1082,6 +1162,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   logger: any
   path: ^1.9.0
   riverpod_annotation: ^2.3.5
+  shared_preferences: ^2.3.2
   sqflite: ^2.3.3+2
   sqflite_common_ffi_web: ^0.4.5+1
 


### PR DESCRIPTION
## Summary
- Add LastStageService to persist and restore the last visited stage number
- Update CurrentStageNo provider to use AsyncValue for async state management
- Modify stage navigation buttons to save stage changes automatically
- Add shared_preferences dependency for local storage
- Update UI to handle async stage number state properly

## Changes Made
- **New Service**: `LastStageService` class for managing stage persistence using SharedPreferences
- **State Management**: Updated `CurrentStageNo` provider to use `AsyncValue<int>` instead of synchronous `int`
- **Navigation**: Modified prev/next buttons to use async methods and save stage changes
- **UI Updates**: Added proper handling of async stage number state in the UI components
- **Dependencies**: Added `shared_preferences` package for local storage

## Test Plan
- [ ] Test stage navigation persists between app sessions
- [ ] Test initial app launch loads last visited stage
- [ ] Test stage navigation buttons work correctly
- [ ] Test edge cases (first stage, invalid stage numbers)
- [ ] Test app behavior when SharedPreferences fails
- [ ] Verify UI shows appropriate loading states during async operations

🤖 Generated with [Claude Code](https://claude.ai/code)