### PR TITLE
Fix Previous button disabled state for Stage 1

### DIFF
--- a/lib/src/features/stage/stage_page.dart
+++ b/lib/src/features/stage/stage_page.dart
@@ -63,9 +63,12 @@ class _Header extends ConsumerWidget {
           Expanded(
             flex: isSmallScreen ? 1 : 2,
             child: FilledButton(
-              onPressed: () async {
-                await ref.read(currentStageNoProvider.notifier).prev();
-              },
+              onPressed:
+                  currentStageNo > 1
+                      ? () async {
+                        await ref.read(currentStageNoProvider.notifier).prev();
+                      }
+                      : null,
               child: Text(isSmallScreen ? '前' : '前へ'),
             ),
           ),


### PR DESCRIPTION
closed https://github.com/noboru-i/kyouen-flutter/issues/54

## Summary
- Disable the Previous button when displaying Stage 1 since stages start from 1
- The button is now only enabled for stages 2 and above using `currentStageNo > 1` condition

## Test plan
- [ ] Navigate to Stage 1 and verify Previous button is disabled
- [ ] Navigate to Stage 2 and verify Previous button is enabled  
- [ ] Navigate to Stage 3+ and verify Previous button remains enabled
- [ ] Verify button styling appears correctly in disabled state

🤖 Generated with [Claude Code](https://claude.ai/code)