### PR TITLE
Add kyouen answer overlay and success dialog

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/src/features/stage/stage_page.dart
+++ b/lib/src/features/stage/stage_page.dart
@@ -8,7 +8,12 @@ import 'package:kyouen_flutter/src/widgets/common/kyouen_answer_overlay_widget.d
 import 'package:kyouen_flutter/src/widgets/common/kyouen_success_dialog.dart';
 
 // State for controlling kyouen overlay visibility
-final showKyouenOverlayProvider = StateProvider<bool>((ref) => false);
+// Automatically resets when currentStageNoProvider changes
+final showKyouenOverlayProvider = StateProvider<bool>((ref) {
+  // Watch currentStageNoProvider to trigger reset when stage changes
+  ref.watch(currentStageNoProvider);
+  return false;
+});
 
 class StagePage extends ConsumerWidget {
   const StagePage({super.key});
@@ -71,8 +76,6 @@ class _Header extends ConsumerWidget {
               onPressed:
                   currentStageNo > 1
                       ? () async {
-                        ref.read(showKyouenOverlayProvider.notifier).state =
-                            false;
                         await ref.read(currentStageNoProvider.notifier).prev();
                       }
                       : null,
@@ -111,7 +114,6 @@ class _Header extends ConsumerWidget {
             flex: isSmallScreen ? 1 : 2,
             child: FilledButton(
               onPressed: () async {
-                ref.read(showKyouenOverlayProvider.notifier).state = false;
                 await ref.read(currentStageNoProvider.notifier).next();
               },
               child: Text(isSmallScreen ? '次' : '次へ'),
@@ -161,9 +163,6 @@ class _Footer extends ConsumerWidget {
                         context: context,
                         onClose: () {
                           Navigator.of(context).pop();
-                          // Hide overlay and go to next stage
-                          ref.read(showKyouenOverlayProvider.notifier).state =
-                              false;
                         },
                       );
                       await ref.read(currentStageNoProvider.notifier).next();

--- a/lib/src/features/stage/stage_page.dart
+++ b/lib/src/features/stage/stage_page.dart
@@ -230,7 +230,7 @@ class _Body extends ConsumerWidget {
                       kyouenData: kyouenData,
                       boardSize: boardSize,
                       isVisible: true,
-                      strokeColor: const Color(0xFF4CAF50),
+                      strokeColor: const Color(0xFFFF6B35),
                       strokeWidth: 4,
                       animationDuration: const Duration(milliseconds: 1200),
                     );

--- a/lib/src/features/stage/stage_page.dart
+++ b/lib/src/features/stage/stage_page.dart
@@ -229,9 +229,6 @@ class _Body extends ConsumerWidget {
                     return KyouenAnswerOverlayWidget(
                       kyouenData: kyouenData,
                       boardSize: boardSize,
-                      isVisible: true,
-                      strokeColor: const Color(0xFFFF6B35),
-                      strokeWidth: 4,
                       animationDuration: const Duration(milliseconds: 1200),
                     );
                   }

--- a/lib/src/features/stage/stage_service.dart
+++ b/lib/src/features/stage/stage_service.dart
@@ -196,6 +196,11 @@ class CurrentStage extends _$CurrentStage {
     return kyouenStage.hasKyouen() != null;
   }
 
+  KyouenData? getKyouenData() {
+    final kyouenStage = Kyouen(stonesFromString(state.asData!.value.stage));
+    return kyouenStage.hasKyouen();
+  }
+
   Future<void> markCurrentStageCleared() async {
     final currentStageNoAsync = ref.read(currentStageNoProvider);
     final currentStageNo = currentStageNoAsync.when(

--- a/lib/src/widgets/common/circle_overlay_widget.dart
+++ b/lib/src/widgets/common/circle_overlay_widget.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+class CircleOverlayWidget extends StatefulWidget {
+  const CircleOverlayWidget({
+    super.key,
+    required this.child,
+    required this.isVisible,
+    this.circleColor = Colors.white,
+    this.animationDuration = const Duration(milliseconds: 1000),
+    this.circleRadius = 100.0,
+  });
+
+  final Widget child;
+  final bool isVisible;
+  final Color circleColor;
+  final Duration animationDuration;
+  final double circleRadius;
+
+  @override
+  State<CircleOverlayWidget> createState() => _CircleOverlayWidgetState();
+}
+
+class _CircleOverlayWidgetState extends State<CircleOverlayWidget>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _scaleAnimation;
+  late Animation<double> _opacityAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: widget.animationDuration,
+      vsync: this,
+    );
+
+    _scaleAnimation = Tween<double>(
+      begin: 0,
+      end: 1,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.elasticOut));
+
+    _opacityAnimation = Tween<double>(
+      begin: 1,
+      end: 0.7,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+  }
+
+  @override
+  void didUpdateWidget(CircleOverlayWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isVisible && !oldWidget.isVisible) {
+      _controller.forward();
+    } else if (!widget.isVisible && oldWidget.isVisible) {
+      _controller.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        widget.child,
+        if (widget.isVisible)
+          AnimatedBuilder(
+            animation: _controller,
+            builder: (context, child) {
+              return Positioned.fill(
+                child: ColoredBox(
+                  color: Colors.black.withValues(
+                    alpha: 0.1 * _opacityAnimation.value,
+                  ),
+                  child: Center(
+                    child: Transform.scale(
+                      scale: _scaleAnimation.value,
+                      child: Container(
+                        width: widget.circleRadius * 2,
+                        height: widget.circleRadius * 2,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: widget.circleColor.withValues(alpha: 0.8),
+                          border: Border.all(
+                            color: widget.circleColor,
+                            width: 3,
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: widget.circleColor.withValues(alpha: 0.3),
+                              blurRadius: 20,
+                              spreadRadius: 5,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+      ],
+    );
+  }
+}

--- a/lib/src/widgets/common/kyouen_answer_overlay_widget.dart
+++ b/lib/src/widgets/common/kyouen_answer_overlay_widget.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:kyouen/kyouen.dart';
 
@@ -175,9 +176,22 @@ class KyouenAnswerPainter extends CustomPainter {
 
     final centerX = center.x * cellSize + cellSize / 2;
     final centerY = center.y * cellSize + cellSize / 2;
-    final drawRadius = radius * cellSize * animationValue;
+    final drawRadius = radius * cellSize;
 
-    canvas.drawCircle(Offset(centerX, centerY), drawRadius, paint);
+    // 円弧の長さをアニメーションで調整（大きさは固定）
+    final sweepAngle = 2 * math.pi * animationValue; // 0から2πまで
+    final rect = Rect.fromCircle(
+      center: Offset(centerX, centerY),
+      radius: drawRadius,
+    );
+
+    canvas.drawArc(
+      rect,
+      -math.pi / 2, // 上から開始（-π/2）
+      sweepAngle,
+      false,
+      paint,
+    );
   }
 
   @override

--- a/lib/src/widgets/common/kyouen_answer_overlay_widget.dart
+++ b/lib/src/widgets/common/kyouen_answer_overlay_widget.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:kyouen/kyouen.dart';
+
+class KyouenAnswerOverlayWidget extends StatefulWidget {
+  const KyouenAnswerOverlayWidget({
+    super.key,
+    required this.kyouenData,
+    required this.boardSize,
+    required this.isVisible,
+    this.strokeWidth = 3.0,
+    this.strokeColor = Colors.grey,
+    this.animationDuration = const Duration(milliseconds: 800),
+  });
+
+  final KyouenData kyouenData;
+  final int boardSize;
+  final bool isVisible;
+  final double strokeWidth;
+  final Color strokeColor;
+  final Duration animationDuration;
+
+  @override
+  State<KyouenAnswerOverlayWidget> createState() =>
+      _KyouenAnswerOverlayWidgetState();
+}
+
+class _KyouenAnswerOverlayWidgetState extends State<KyouenAnswerOverlayWidget>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: widget.animationDuration,
+      vsync: this,
+    );
+    _animation = Tween<double>(
+      begin: 0,
+      end: 1,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.isVisible) {
+      return const SizedBox.shrink();
+    }
+
+    return Center(
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: Card(
+          color: Colors.transparent,
+          elevation: 8,
+          child: AnimatedBuilder(
+            animation: _animation,
+            builder: (context, child) {
+              return CustomPaint(
+                painter: KyouenAnswerPainter(
+                  kyouenData: widget.kyouenData,
+                  boardSize: widget.boardSize,
+                  strokeWidth: widget.strokeWidth,
+                  strokeColor: widget.strokeColor,
+                  animationValue: _animation.value,
+                ),
+                child: Container(),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class KyouenAnswerPainter extends CustomPainter {
+  const KyouenAnswerPainter({
+    required this.kyouenData,
+    required this.boardSize,
+    required this.strokeWidth,
+    required this.strokeColor,
+    required this.animationValue,
+  });
+
+  final KyouenData kyouenData;
+  final int boardSize;
+  final double strokeWidth;
+  final Color strokeColor;
+  final double animationValue;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint =
+        Paint()
+          ..color = strokeColor.withValues(alpha: animationValue)
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = strokeWidth;
+
+    final cellSize = size.width / boardSize;
+
+    if (kyouenData.isLineKyouen) {
+      // 直線の場合
+      _drawLine(canvas, size, paint, cellSize);
+    } else {
+      // 円の場合
+      _drawCircle(canvas, size, paint, cellSize);
+    }
+  }
+
+  void _drawLine(Canvas canvas, Size size, Paint paint, double cellSize) {
+    final line = kyouenData.line;
+    if (line == null) {
+      return;
+    }
+
+    double startX;
+    double startY;
+    double stopX;
+    double stopY;
+
+    if (line.a == 0) {
+      // x軸と平行な場合
+      startX = 0;
+      startY = line.getY(0) * cellSize + cellSize / 2;
+      stopX = size.width;
+      stopY = line.getY(0) * cellSize + cellSize / 2;
+    } else if (line.b == 0) {
+      // y軸と平行な場合
+      startX = line.getX(0) * cellSize + cellSize / 2;
+      startY = 0;
+      stopX = line.getX(0) * cellSize + cellSize / 2;
+      stopY = size.height;
+    } else {
+      // 一般的な場合
+      if (-line.c / line.b > 0) {
+        startX = 0;
+        startY = line.getY(-0.5) * cellSize + cellSize / 2;
+        stopX = size.width;
+        stopY = line.getY(boardSize - 0.5) * cellSize + cellSize / 2;
+      } else {
+        startX = line.getX(-0.5) * cellSize + cellSize / 2;
+        startY = 0;
+        stopX = line.getX(boardSize - 0.5) * cellSize + cellSize / 2;
+        stopY = size.height;
+      }
+    }
+
+    // アニメーションに応じて線の長さを調整
+    final animatedEndX = startX + (stopX - startX) * animationValue;
+    final animatedEndY = startY + (stopY - startY) * animationValue;
+
+    canvas.drawLine(
+      Offset(startX, startY),
+      Offset(animatedEndX, animatedEndY),
+      paint,
+    );
+  }
+
+  void _drawCircle(Canvas canvas, Size size, Paint paint, double cellSize) {
+    final center = kyouenData.center;
+    final radius = kyouenData.radius;
+
+    if (center == null || radius == null) {
+      return;
+    }
+
+    final centerX = center.x * cellSize + cellSize / 2;
+    final centerY = center.y * cellSize + cellSize / 2;
+    final drawRadius = radius * cellSize * animationValue;
+
+    canvas.drawCircle(Offset(centerX, centerY), drawRadius, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return oldDelegate is KyouenAnswerPainter &&
+        oldDelegate.animationValue != animationValue;
+  }
+}

--- a/lib/src/widgets/common/kyouen_answer_overlay_widget.dart
+++ b/lib/src/widgets/common/kyouen_answer_overlay_widget.dart
@@ -7,17 +7,11 @@ class KyouenAnswerOverlayWidget extends StatefulWidget {
     super.key,
     required this.kyouenData,
     required this.boardSize,
-    required this.isVisible,
-    this.strokeWidth = 3.0,
-    this.strokeColor = Colors.grey,
     this.animationDuration = const Duration(milliseconds: 800),
   });
 
   final KyouenData kyouenData;
   final int boardSize;
-  final bool isVisible;
-  final double strokeWidth;
-  final Color strokeColor;
   final Duration animationDuration;
 
   @override
@@ -52,16 +46,12 @@ class _KyouenAnswerOverlayWidgetState extends State<KyouenAnswerOverlayWidget>
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.isVisible) {
-      return const SizedBox.shrink();
-    }
-
     return Center(
       child: AspectRatio(
         aspectRatio: 1,
         child: Card(
           color: Colors.transparent,
-          elevation: 8,
+          elevation: 0,
           child: AnimatedBuilder(
             animation: _animation,
             builder: (context, child) {
@@ -69,8 +59,6 @@ class _KyouenAnswerOverlayWidgetState extends State<KyouenAnswerOverlayWidget>
                 painter: KyouenAnswerPainter(
                   kyouenData: widget.kyouenData,
                   boardSize: widget.boardSize,
-                  strokeWidth: widget.strokeWidth,
-                  strokeColor: widget.strokeColor,
                   animationValue: _animation.value,
                 ),
                 child: Container(),
@@ -87,24 +75,20 @@ class KyouenAnswerPainter extends CustomPainter {
   const KyouenAnswerPainter({
     required this.kyouenData,
     required this.boardSize,
-    required this.strokeWidth,
-    required this.strokeColor,
     required this.animationValue,
   });
 
   final KyouenData kyouenData;
   final int boardSize;
-  final double strokeWidth;
-  final Color strokeColor;
   final double animationValue;
 
   @override
   void paint(Canvas canvas, Size size) {
     final paint =
         Paint()
-          ..color = strokeColor.withValues(alpha: animationValue)
+          ..color = const Color(0xFFFF6B35)
           ..style = PaintingStyle.stroke
-          ..strokeWidth = strokeWidth;
+          ..strokeWidth = 4;
 
     final cellSize = size.width / boardSize;
 

--- a/lib/src/widgets/common/kyouen_success_dialog.dart
+++ b/lib/src/widgets/common/kyouen_success_dialog.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+class KyouenSuccessDialog extends StatefulWidget {
+  const KyouenSuccessDialog({super.key, required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  State<KyouenSuccessDialog> createState() => _KyouenSuccessDialogState();
+}
+
+class _KyouenSuccessDialogState extends State<KyouenSuccessDialog> {
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.95),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.check_circle, color: Color(0xFF4CAF50), size: 48),
+                SizedBox(width: 8),
+                Text(
+                  '共円！！',
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF2E7D32),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: widget.onClose,
+                style: FilledButton.styleFrom(
+                  backgroundColor: const Color(0xFF4CAF50),
+                  foregroundColor: Colors.white,
+                ),
+                child: const Text('次のステージへ'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> showKyouenSuccessDialog({
+  required BuildContext context,
+  required VoidCallback onClose,
+}) {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    barrierColor: Colors.black.withValues(alpha: 0.3),
+    builder: (context) => KyouenSuccessDialog(onClose: onClose),
+  );
+}

--- a/lib/src/widgets/common/kyouen_success_dialog.dart
+++ b/lib/src/widgets/common/kyouen_success_dialog.dart
@@ -15,44 +15,47 @@ class _KyouenSuccessDialogState extends State<KyouenSuccessDialog> {
     return Dialog(
       backgroundColor: Colors.transparent,
       elevation: 0,
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.95),
-          borderRadius: BorderRadius.circular(16),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.check_circle, color: Color(0xFF4CAF50), size: 48),
-                SizedBox(width: 8),
-                Text(
-                  '共円！！',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Color(0xFF2E7D32),
+      child: Opacity(
+        opacity: 0.8,
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.check_circle, color: Color(0xFF4CAF50), size: 48),
+                  SizedBox(width: 8),
+                  Text(
+                    '共円！！',
+                    style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                      color: Color(0xFF2E7D32),
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: widget.onClose,
-                style: FilledButton.styleFrom(
-                  backgroundColor: const Color(0xFF4CAF50),
-                  foregroundColor: Colors.white,
-                ),
-                child: const Text('次のステージへ'),
+                ],
               ),
-            ),
-          ],
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: widget.onClose,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: const Color(0xFF4CAF50),
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('次のステージへ'),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- 共円（kyouen）解答時の視覚的フィードバックを追加
- 解答の円と線を表示するオーバーレイウィジェット実装
- 成功時の再利用可能なダイアログコンポーネント追加

## Changes
- **KyouenAnswerOverlayWidget**: 解答の円と線を表示するオーバーレイウィジェット
- **KyouenSuccessDialog**: 成功時の再利用可能なダイアログコンポーネント
- **CircleOverlayWidget**: 基本的な円描画ウィジェット
- **stage_page.dart**: 新しいオーバーレイシステムの使用にリファクタリング
- **stage_service.dart**: `getKyouenData()` メソッドを追加

## Test plan
- [ ] 共円が成立するステージでゲームをプレイ
- [ ] 解答時に円と線のオーバーレイが正しく表示されることを確認
- [ ] 成功ダイアログが正しく表示されることを確認
- [ ] 次のステージに正しく移行することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)