### PR TITLE
Firebase認証トークンの自動付与とClearStageパラメータの改善

### DIFF
--- a/lib/src/data/api/api_client.dart
+++ b/lib/src/data/api/api_client.dart
@@ -10,6 +10,7 @@ import 'package:kyouen_flutter/src/data/api/entity/login_response.dart';
 import 'package:kyouen_flutter/src/data/api/entity/new_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/recent_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/stage_response.dart';
+import 'package:kyouen_flutter/src/data/api/firebase_auth_interceptor.dart';
 import 'package:kyouen_flutter/src/data/api/json_serializable_converter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -56,7 +57,10 @@ ApiClient apiClient(Ref ref) {
     baseUrl: Uri.parse(Environment.apiBaseUrl),
     services: [ApiClient.create()],
     converter: JsonSerializableConverter(),
-    interceptors: [if (kDebugMode) HttpLoggingInterceptor()],
+    interceptors: [
+      FirebaseAuthInterceptor(),
+      if (kDebugMode) HttpLoggingInterceptor(),
+    ],
   );
   return ApiClient.create(client);
 }

--- a/lib/src/data/api/entity/clear_stage.dart
+++ b/lib/src/data/api/entity/clear_stage.dart
@@ -5,7 +5,8 @@ part 'clear_stage.g.dart';
 
 @freezed
 abstract class ClearStage with _$ClearStage {
-  const factory ClearStage({required String clearDate}) = _ClearStage;
+  const factory ClearStage({required String stage, required String clearDate}) =
+      _ClearStage;
 
   factory ClearStage.fromJson(Map<String, Object?> json) =>
       _$ClearStageFromJson(json);

--- a/lib/src/data/api/firebase_auth_interceptor.dart
+++ b/lib/src/data/api/firebase_auth_interceptor.dart
@@ -1,0 +1,48 @@
+import 'package:chopper/chopper.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
+
+/// Firebase認証トークンを自動的にAPIリクエストに含めるInterceptor
+class FirebaseAuthInterceptor implements Interceptor {
+  static final _logger = Logger();
+
+  @override
+  Future<Response<BodyType>> intercept<BodyType>(Chain<BodyType> chain) async {
+    final request = chain.request;
+
+    try {
+      // Firebase認証の現在のユーザーを取得
+      final user = FirebaseAuth.instance.currentUser;
+
+      if (user != null) {
+        // Firebase IDトークンを取得
+        final token = await user.getIdToken();
+
+        // AuthorizationヘッダーにBearerトークンを追加
+        final newRequest = request.copyWith(
+          headers: {...request.headers, 'Authorization': 'Bearer $token'},
+        );
+
+        if (kDebugMode) {
+          _logger.d('Firebase Auth Interceptor: Token added to request');
+        }
+
+        return chain.proceed(newRequest);
+      } else {
+        if (kDebugMode) {
+          _logger.d(
+            'Firebase Auth Interceptor: No authenticated user, proceeding without token',
+          );
+        }
+        return chain.proceed(request);
+      }
+    } on Exception catch (e) {
+      if (kDebugMode) {
+        _logger.e('Firebase Auth Interceptor: Error getting token: $e');
+      }
+      // エラーが発生した場合はトークンなしで続行
+      return chain.proceed(request);
+    }
+  }
+}

--- a/lib/src/data/repository/stage_repository.dart
+++ b/lib/src/data/repository/stage_repository.dart
@@ -83,9 +83,12 @@ class StageRepository {
     throw Exception('Failed to create stage: ${response.error}');
   }
 
-  Future<void> clearStage(int stageNo) async {
+  Future<void> clearStage(int stageNo, String userStage) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final clearStage = ClearStage(clearDate: DateTime.now().toIso8601String());
+    final clearStage = ClearStage(
+      stage: userStage,
+      clearDate: DateTime.now().toIso8601String(),
+    );
 
     await _apiClient.clearStage(stageNo, clearStage);
 

--- a/lib/src/features/stage/stage_service.dart
+++ b/lib/src/features/stage/stage_service.dart
@@ -209,8 +209,11 @@ class CurrentStage extends _$CurrentStage {
       error: (_, _) => 1,
     );
 
+    // Get the current stage state (user's solution)
+    final currentStageState = state.asData!.value.stage;
+
     final stageRepository = await ref.read(stageRepositoryProvider.future);
-    await stageRepository.clearStage(currentStageNo);
+    await stageRepository.clearStage(currentStageNo, currentStageState);
 
     // Invalidate the cleared stages provider to refresh UI
     ref.invalidate(clearedStageNumbersProvider);


### PR DESCRIPTION
## Summary
- Firebase認証トークンを自動的にAPIリクエストに含めるInterceptorを追加
- API仕様に合わせてClearStageエンティティにstageフィールドを追加
- clearStageメソッドでユーザーの解答（石の配置）を送信するよう更新

## 変更内容
- **FirebaseAuthInterceptor**: Firebase認証トークンを自動的に`Authorization: Bearer`ヘッダーに追加
- **ClearStageエンティティ**: API仕様に合わせて`stage`フィールドを追加
- **StageRepository**: clearStageメソッドでユーザーの解答を受け取るよう更新
- **StageService**: ステージクリア時に現在のステージ状態を送信

## Test plan
- [ ] Firebase認証済みユーザーでAPIリクエストにトークンが含まれることを確認
- [ ] ステージクリア時にユーザーの解答がサーバーに送信されることを確認
- [ ] 認証されていないユーザーでもAPIリクエストが正常に動作することを確認
- [ ] 既存のテストが全て通過することを確認

関連issue: #63

🤖 Generated with [Claude Code](https://claude.ai/code)