### PR TITLE
fix: APIエンティティのフィールド名をサーバーAPIスペックに合わせて修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,15 @@ flutterfire configure \
 ## コード生成設定
 
 ### build.yaml
-- **json_serializable**: API entities用にsnake_case field namingで設定
+- **json_serializable**: API entities用にsnake_case field namingで設定 (`field_rename: snake`)
 - **freezed**: API entities用のimmutable data classを生成
 - **対象ディレクトリ**: `lib/src/data/**/*.dart`
+
+### JSON フィールド命名規則
+- **重要**: `build.yaml`で`field_rename: snake`が設定されているため、通常は`@JsonKey`アノテーションは不要
+- Dartのフィールド名（camelCase）は自動的にJSON（snake_case）に変換される
+- 例: `stageNo` → `stage_no`, `screenName` → `screen_name`
+- APIスペックと異なる場合のみ`@JsonKey(name: 'custom_name')`を使用
 
 ### 生成ファイル (gitignore対象)
 - `*.g.dart` - JSON serialization

--- a/lib/src/data/api/api_client.dart
+++ b/lib/src/data/api/api_client.dart
@@ -66,7 +66,7 @@ ApiClient apiClient(Ref ref) {
       LoginResponse: LoginResponse.fromJson,
       RecentStage: RecentStage.fromJson,
       StageResponse: StageResponse.fromJson,
-      ResourceError: ResourceError.fromJsonFactory,
+      ResourceError: ResourceError.fromJson,
     }),
     interceptors: [
       FirebaseAuthInterceptor(),

--- a/lib/src/data/api/api_client.dart
+++ b/lib/src/data/api/api_client.dart
@@ -9,6 +9,7 @@ import 'package:kyouen_flutter/src/data/api/entity/login_request.dart';
 import 'package:kyouen_flutter/src/data/api/entity/login_response.dart';
 import 'package:kyouen_flutter/src/data/api/entity/new_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/recent_stage.dart';
+import 'package:kyouen_flutter/src/data/api/entity/resource_error.dart';
 import 'package:kyouen_flutter/src/data/api/entity/stage_response.dart';
 import 'package:kyouen_flutter/src/data/api/firebase_auth_interceptor.dart';
 import 'package:kyouen_flutter/src/data/api/json_serializable_converter.dart';
@@ -59,7 +60,14 @@ ApiClient apiClient(Ref ref) {
   final client = ChopperClient(
     baseUrl: Uri.parse(Environment.apiBaseUrl),
     services: [ApiClient.create()],
-    converter: JsonSerializableConverter(),
+    converter: const JsonSerializableConverter({
+      ActivityUser: ActivityUser.fromJson,
+      ClearedStage: ClearedStage.fromJson,
+      LoginResponse: LoginResponse.fromJson,
+      RecentStage: RecentStage.fromJson,
+      StageResponse: StageResponse.fromJson,
+      ResourceError: ResourceError.fromJsonFactory,
+    }),
     interceptors: [
       FirebaseAuthInterceptor(),
       if (kDebugMode) HttpLoggingInterceptor(),

--- a/lib/src/data/api/entity/activity_user.dart
+++ b/lib/src/data/api/entity/activity_user.dart
@@ -7,7 +7,7 @@ part 'activity_user.g.dart';
 abstract class ActivityUser with _$ActivityUser {
   const factory ActivityUser({
     required String screenName,
-    required String profileImageUrl,
+    required String image,
     required List<ClearedStageActivity> clearedStages,
   }) = _ActivityUser;
 
@@ -19,7 +19,7 @@ abstract class ActivityUser with _$ActivityUser {
 abstract class ClearedStageActivity with _$ClearedStageActivity {
   const factory ClearedStageActivity({
     required int stageNo,
-    required String clearedDate,
+    required String clearDate,
   }) = _ClearedStageActivity;
 
   factory ClearedStageActivity.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/data/api/entity/activity_user.dart
+++ b/lib/src/data/api/entity/activity_user.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_annotation_target
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'activity_user.freezed.dart';
@@ -6,8 +8,9 @@ part 'activity_user.g.dart';
 @freezed
 abstract class ActivityUser with _$ActivityUser {
   const factory ActivityUser({
-    required String screenName,
+    @JsonKey(name: 'screenName') required String screenName,
     required String image,
+    @JsonKey(name: 'clearedStages')
     required List<ClearedStageActivity> clearedStages,
   }) = _ActivityUser;
 
@@ -18,8 +21,8 @@ abstract class ActivityUser with _$ActivityUser {
 @freezed
 abstract class ClearedStageActivity with _$ClearedStageActivity {
   const factory ClearedStageActivity({
-    required int stageNo,
-    required String clearDate,
+    @JsonKey(name: 'stageNo') required int stageNo,
+    @JsonKey(name: 'clearDate') required String clearDate,
   }) = _ClearedStageActivity;
 
   factory ClearedStageActivity.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/data/api/entity/recent_stage.dart
+++ b/lib/src/data/api/entity/recent_stage.dart
@@ -8,9 +8,9 @@ abstract class RecentStage with _$RecentStage {
   const factory RecentStage({
     required int stageNo,
     required int size,
-    required String stageDefinition,
-    required String creatorName,
-    required String registeredDate,
+    required String stage,
+    required String creator,
+    required String registDate,
   }) = _RecentStage;
 
   factory RecentStage.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/data/api/entity/resource_error.dart
+++ b/lib/src/data/api/entity/resource_error.dart
@@ -4,12 +4,13 @@ part 'resource_error.g.dart';
 
 @JsonSerializable()
 class ResourceError {
-  final String type;
-  final String message;
-
   ResourceError(this.type, this.message);
 
-  static const fromJsonFactory = _$ResourceErrorFromJson;
+  static const ResourceError Function(Map<String, dynamic>) fromJson =
+      _$ResourceErrorFromJson;
+
+  final String type;
+  final String message;
 
   Map<String, dynamic> toJson() => _$ResourceErrorToJson(this);
 }

--- a/lib/src/data/api/entity/resource_error.dart
+++ b/lib/src/data/api/entity/resource_error.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'resource_error.g.dart';
+
+@JsonSerializable()
+class ResourceError {
+  final String type;
+  final String message;
+
+  ResourceError(this.type, this.message);
+
+  static const fromJsonFactory = _$ResourceErrorFromJson;
+
+  Map<String, dynamic> toJson() => _$ResourceErrorToJson(this);
+}

--- a/lib/src/data/api/json_serializable_converter.dart
+++ b/lib/src/data/api/json_serializable_converter.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 
 import 'package:chopper/chopper.dart';
+import 'package:kyouen_flutter/src/data/api/entity/activity_user.dart';
 import 'package:kyouen_flutter/src/data/api/entity/cleared_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/login_response.dart';
+import 'package:kyouen_flutter/src/data/api/entity/recent_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/stage_response.dart';
 
 class JsonSerializableConverter extends JsonConverter {
@@ -42,6 +44,18 @@ class JsonSerializableConverter extends JsonConverter {
       return jsonList
               .map(
                 (item) => ClearedStage.fromJson(item as Map<String, dynamic>),
+              )
+              .toList()
+          as T;
+    } else if (InnerType == RecentStage) {
+      return jsonList
+              .map((item) => RecentStage.fromJson(item as Map<String, dynamic>))
+              .toList()
+          as T;
+    } else if (InnerType == ActivityUser) {
+      return jsonList
+              .map(
+                (item) => ActivityUser.fromJson(item as Map<String, dynamic>),
               )
               .toList()
           as T;

--- a/lib/src/data/api/json_serializable_converter.dart
+++ b/lib/src/data/api/json_serializable_converter.dart
@@ -62,7 +62,7 @@ class JsonSerializableConverter extends JsonConverter {
     final jsonRes = await super.convertError<dynamic, dynamic>(response);
 
     return jsonRes.copyWith<ResourceError>(
-      body: ResourceError.fromJsonFactory(jsonRes.body as Map<String, dynamic>),
+      body: ResourceError.fromJson(jsonRes.body as Map<String, dynamic>),
     );
   }
 }

--- a/lib/src/features/title/web_title_page.dart
+++ b/lib/src/features/title/web_title_page.dart
@@ -185,11 +185,15 @@ class _RecentStagesDisplay extends ConsumerWidget {
 
     return recentStagesAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error:
-          (error, _) => Text(
-            'エラーが発生しました',
-            style: TextStyle(fontSize: 14, color: Colors.red.shade700),
-          ),
+      error: (error, trace) {
+        // Error fetching recent stages: $error
+        print('Error fetching recent stages: $error');
+        print('Stack trace: $trace');
+        return Text(
+          'エラーが発生しました',
+          style: TextStyle(fontSize: 14, color: Colors.red.shade700),
+        );
+      },
       data:
           (stages) => Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -210,7 +214,7 @@ class _RecentStagesDisplay extends ConsumerWidget {
                             const SizedBox(width: 8),
                             Expanded(
                               child: Text(
-                                '${stage.creatorName} - ${stage.registeredDate}',
+                                '${stage.creator} - ${stage.registDate}',
                                 style: const TextStyle(
                                   fontSize: 12,
                                   color: Colors.black54,
@@ -255,7 +259,7 @@ class _ActivitiesDisplay extends ConsumerWidget {
                             ClipRRect(
                               borderRadius: BorderRadius.circular(16),
                               child: Image.network(
-                                activity.profileImageUrl,
+                                activity.image,
                                 width: 32,
                                 height: 32,
                                 errorBuilder:

--- a/lib/src/features/title/web_title_page.dart
+++ b/lib/src/features/title/web_title_page.dart
@@ -186,9 +186,6 @@ class _RecentStagesDisplay extends ConsumerWidget {
     return recentStagesAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, trace) {
-        // Error fetching recent stages: $error
-        print('Error fetching recent stages: $error');
-        print('Stack trace: $trace');
         return Text(
           'エラーが発生しました',
           style: TextStyle(fontSize: 14, color: Colors.red.shade700),


### PR DESCRIPTION
close https://github.com/noboru-i/kyouen-flutter/issues/70

## Summary
- サーバーのAPIドキュメント（docs/specs/index.yaml）に基づいてAPIエンティティのフィールド名を修正
- JsonSerializableConverterを型安全なfactory mapベースの実装に更新
- エラーハンドリングを改善するためのResourceErrorエンティティを追加
- すべてのDart linting warningsを解決してコード品質を向上

## 変更内容
### APIエンティティのフィールド名修正
- **RecentStage**: `stageDefinition`→`stage`, `creatorName`→`creator`, `registeredDate`→`registDate`
- **ActivityUser**: `profileImageUrl`→`image`
- **ClearedStageActivity**: `clearedDate`→`clearDate`
- **web_title_page.dart**: 変更されたフィールド名に合わせて参照箇所を更新

### JsonSerializableConverterの改良
- 旧実装：URLパターンベースの変換処理
- 新実装：型安全なfactory mapベースの変換処理
- より堅牢で保守性の高いJSON変換を実現

### エラーハンドリングの改善
- **ResourceError**エンティティを追加
- APIエラーレスポンスの適切な型変換処理を実装
- 統一された命名規則（`fromJson`）を採用

### コード品質の向上
- **Lint warnings解決**: すべてのDart linting warningsを修正
- **コンストラクタ順序**: `sort_constructors_first`に準拠
- **型アノテーション**: 明示的な型指定で可読性を向上
- **プロダクションコード**: print文を削除してクリーンなコードを実現

### その他
- **CLAUDE.md**: JSON命名規則のガイドラインを追加
- 適切な `@JsonKey` アノテーションの設定
- コード生成による整合性の確保

## 修正した問題
- `TypeError: type 'List<dynamic>' is not a subtype of type 'List<RecentStage>'` エラーを解決
- サーバーAPIとクライアントエンティティの不整合を解消
- JSON変換処理の型安全性を向上
- すべてのDart linting warningsを解決（flutter analyze結果: No issues found\!）

## Test plan
- [ ] アプリケーションを起動してRecent Stagesが正しく表示されることを確認
- [ ] Activitiesが正しく表示されることを確認
- [ ] APIエラー時のエラーハンドリングが正しく動作することを確認
- [x] flutter analyzeでエラー/ワーニングがないことを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)