### PR TITLE
Improve stage clear data management with server sync

### DIFF
--- a/lib/src/data/api/entity/stage_response.dart
+++ b/lib/src/data/api/entity/stage_response.dart
@@ -12,6 +12,7 @@ abstract class StageResponse with _$StageResponse {
     required String stage,
     required String creator,
     required String registDate,
+    String? clearDate,
   }) = _StageResponse;
 
   factory StageResponse.fromJson(Map<String, Object?> json) =>

--- a/lib/src/data/local/cleared_stage_count_service.dart
+++ b/lib/src/data/local/cleared_stage_count_service.dart
@@ -1,0 +1,20 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ClearedStageCountService {
+  static const _key = 'cleared_stage_count';
+
+  Future<int?> getRawCount() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_key);
+  }
+
+  Future<void> saveCount(int count) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_key, count);
+  }
+
+  Future<void> increment() async {
+    final current = await getRawCount() ?? 0;
+    await saveCount(current + 1);
+  }
+}

--- a/lib/src/data/local/dao/tume_kyouen_dao.dart
+++ b/lib/src/data/local/dao/tume_kyouen_dao.dart
@@ -83,4 +83,36 @@ class TumeKyouenDao {
       whereArgs: [stageNo],
     );
   }
+
+  /// Inserts new stages and updates metadata for existing ones, preserving clear_flag/clear_date.
+  Future<void> insertOrUpdateStages(List<TumeKyouen> tumeKyouens) async {
+    final batch = _database.batch();
+    for (final tumeKyouen in tumeKyouens) {
+      batch.insert(
+        _tableName,
+        tumeKyouen.toJson()..remove('uid'),
+        conflictAlgorithm: ConflictAlgorithm.ignore,
+      );
+      batch.rawUpdate(
+        'UPDATE $_tableName SET size=?, stage=?, creator=? WHERE stage_no=?',
+        [tumeKyouen.size, tumeKyouen.stage, tumeKyouen.creator, tumeKyouen.stageNo],
+      );
+    }
+    await batch.commit();
+  }
+
+  /// Bulk-updates clear status from server sync response.
+  /// Only updates stages that already exist locally.
+  Future<void> updateClearStatuses(Map<int, int> clearDateByStageNo) async {
+    final batch = _database.batch();
+    for (final entry in clearDateByStageNo.entries) {
+      batch.update(
+        _tableName,
+        {'clear_flag': TumeKyouen.cleared, 'clear_date': entry.value},
+        where: 'stage_no = ?',
+        whereArgs: [entry.key],
+      );
+    }
+    await batch.commit();
+  }
 }

--- a/lib/src/data/local/dao/tume_kyouen_dao.dart
+++ b/lib/src/data/local/dao/tume_kyouen_dao.dart
@@ -88,15 +88,21 @@ class TumeKyouenDao {
   Future<void> insertOrUpdateStages(List<TumeKyouen> tumeKyouens) async {
     final batch = _database.batch();
     for (final tumeKyouen in tumeKyouens) {
-      batch.insert(
-        _tableName,
-        tumeKyouen.toJson()..remove('uid'),
-        conflictAlgorithm: ConflictAlgorithm.ignore,
-      );
-      batch.rawUpdate(
-        'UPDATE $_tableName SET size=?, stage=?, creator=? WHERE stage_no=?',
-        [tumeKyouen.size, tumeKyouen.stage, tumeKyouen.creator, tumeKyouen.stageNo],
-      );
+      batch
+        ..insert(
+          _tableName,
+          tumeKyouen.toJson()..remove('uid'),
+          conflictAlgorithm: ConflictAlgorithm.ignore,
+        )
+        ..rawUpdate(
+          'UPDATE $_tableName SET size=?, stage=?, creator=? WHERE stage_no=?',
+          [
+            tumeKyouen.size,
+            tumeKyouen.stage,
+            tumeKyouen.creator,
+            tumeKyouen.stageNo,
+          ],
+        );
     }
     await batch.commit();
   }

--- a/lib/src/data/repository/stage_repository.dart
+++ b/lib/src/data/repository/stage_repository.dart
@@ -3,6 +3,7 @@ import 'package:kyouen_flutter/src/data/api/entity/clear_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/cleared_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/new_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/stage_response.dart';
+import 'package:kyouen_flutter/src/data/local/cleared_stage_count_service.dart';
 import 'package:kyouen_flutter/src/data/local/dao/tume_kyouen_dao.dart';
 import 'package:kyouen_flutter/src/data/local/database.dart';
 import 'package:kyouen_flutter/src/data/local/entity/tume_kyouen.dart';
@@ -24,18 +25,17 @@ Future<Set<int>> clearedStageNumbers(Ref ref) async {
 }
 
 @riverpod
-Future<Map<String, int>> stageCount(Ref ref) async {
-  // Depend on clearedStageNumbers so this refreshes when clear status changes.
-  ref.watch(clearedStageNumbersProvider);
+Future<int> clearedStageCount(Ref ref) async {
   final repository = await ref.watch(stageRepositoryProvider.future);
-  return repository.getStageCount();
+  return repository.getClearedCount();
 }
 
 class StageRepository {
-  const StageRepository(this._apiClient, this._dao);
+  StageRepository(this._apiClient, this._dao);
 
   final ApiClient _apiClient;
   final TumeKyouenDao _dao;
+  final _clearedCountService = ClearedStageCountService();
 
   Future<List<StageResponse>> getStages({
     int startStageNo = 1,
@@ -100,6 +100,10 @@ class StageRepository {
       // Offline or API error — the clear is stored locally and will sync later.
     }
 
+    final existing = await _dao.findStage(stageNo);
+    if (existing?.clearFlag != TumeKyouen.cleared) {
+      await _clearedCountService.increment();
+    }
     await _dao.clearStage(stageNo, now);
   }
 
@@ -131,10 +135,26 @@ class StageRepository {
       if (clearDateByStageNo.isNotEmpty) {
         await _dao.updateClearStatuses(clearDateByStageNo);
       }
+      // Server is authoritative: save the exact cleared count it returned.
+      await _clearedCountService.saveCount(response.body!.length);
       return;
     }
 
     throw Exception('Failed to sync stages: ${response.error}');
+  }
+
+  /// Returns the cleared stage count from SharedPreferences.
+  /// On first call (before any sync or clear), seeds from local SQLite so
+  /// existing users see a sensible value immediately after an app update.
+  Future<int> getClearedCount() async {
+    final raw = await _clearedCountService.getRawCount();
+    if (raw == null) {
+      final counts = await _dao.selectStageCount();
+      final localCleared = counts['clear_count'] ?? 0;
+      await _clearedCountService.saveCount(localCleared);
+      return localCleared;
+    }
+    return raw;
   }
 
   // Local database operations
@@ -144,10 +164,6 @@ class StageRepository {
 
   Future<int> getMaxStageNo() {
     return _dao.selectMaxStageNo();
-  }
-
-  Future<Map<String, int>> getStageCount() {
-    return _dao.selectStageCount();
   }
 
   Future<List<TumeKyouen>> getAllClearedStages() {

--- a/lib/src/data/repository/stage_repository.dart
+++ b/lib/src/data/repository/stage_repository.dart
@@ -23,6 +23,14 @@ Future<Set<int>> clearedStageNumbers(Ref ref) async {
   return repository.getClearedStageNumbers();
 }
 
+@riverpod
+Future<Map<String, int>> stageCount(Ref ref) async {
+  // Depend on clearedStageNumbers so this refreshes when clear status changes.
+  ref.watch(clearedStageNumbersProvider);
+  final repository = await ref.watch(stageRepositoryProvider.future);
+  return repository.getStageCount();
+}
+
 class StageRepository {
   const StageRepository(this._apiClient, this._dao);
 
@@ -39,7 +47,6 @@ class StageRepository {
     );
 
     if (response.isSuccessful && response.body != null) {
-      // Save to local database
       final tumeKyouens = response.body!
           .map(
             (stage) => TumeKyouen(
@@ -53,7 +60,7 @@ class StageRepository {
           )
           .toList();
 
-      await _dao.insertAll(tumeKyouens);
+      await _dao.insertOrUpdateStages(tumeKyouens);
       return response.body!;
     }
 
@@ -64,7 +71,6 @@ class StageRepository {
     final response = await _apiClient.createStage(newStage);
 
     if (response.isSuccessful && response.body != null) {
-      // Save to local database
       final tumeKyouen = TumeKyouen(
         stageNo: response.body!.stageNo,
         size: response.body!.size,
@@ -74,7 +80,7 @@ class StageRepository {
         clearDate: 0,
       );
 
-      await _dao.insertAll([tumeKyouen]);
+      await _dao.insertOrUpdateStages([tumeKyouen]);
       return response.body!;
     }
 
@@ -83,18 +89,23 @@ class StageRepository {
 
   Future<void> clearStage(int stageNo, String userStage) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    final clearStage = ClearStage(
-      stage: userStage,
-      clearDate: DateTime.now().toIso8601String(),
-    );
 
-    await _apiClient.clearStage(stageNo, clearStage);
+    try {
+      final clearStageRequest = ClearStage(
+        stage: userStage,
+        clearDate: DateTime.now().toIso8601String(),
+      );
+      await _apiClient.clearStage(stageNo, clearStageRequest);
+    } on Exception catch (_) {
+      // Offline or API error — the clear is stored locally and will sync later.
+    }
 
-    // Always update local database even if API call fails
     await _dao.clearStage(stageNo, now);
   }
 
-  Future<List<ClearedStage>> syncStages() async {
+  /// Sends locally cleared stages to server and updates local DB with the
+  /// server's merged cleared-stage list.
+  Future<void> syncStages() async {
     final clearedStages = await _dao.selectAllClearStage();
     final clearedStageRequests = clearedStages
         .map(
@@ -110,7 +121,16 @@ class StageRepository {
     final response = await _apiClient.syncStages(clearedStageRequests);
 
     if (response.isSuccessful && response.body != null) {
-      return response.body!;
+      final clearDateByStageNo = <int, int>{};
+      for (final cleared in response.body!) {
+        final clearDateMs =
+            DateTime.parse(cleared.clearDate).millisecondsSinceEpoch;
+        clearDateByStageNo[cleared.stageNo] = clearDateMs;
+      }
+      if (clearDateByStageNo.isNotEmpty) {
+        await _dao.updateClearStatuses(clearDateByStageNo);
+      }
+      return;
     }
 
     throw Exception('Failed to sync stages: ${response.error}');
@@ -133,7 +153,6 @@ class StageRepository {
     return _dao.selectAllClearStage();
   }
 
-  // Cleared stages management methods
   Future<Set<int>> getClearedStageNumbers() async {
     final clearedStages = await _dao.selectAllClearStage();
     return clearedStages.map((stage) => stage.stageNo).toSet();

--- a/lib/src/data/repository/stage_repository.dart
+++ b/lib/src/data/repository/stage_repository.dart
@@ -47,7 +47,8 @@ class StageRepository {
     );
 
     if (response.isSuccessful && response.body != null) {
-      final tumeKyouens = response.body!
+      final stages = response.body!;
+      final tumeKyouens = stages
           .map(
             (stage) => TumeKyouen(
               stageNo: stage.stageNo,
@@ -61,7 +62,21 @@ class StageRepository {
           .toList();
 
       await _dao.insertOrUpdateStages(tumeKyouens);
-      return response.body!;
+
+      // Reflect server-side clear status for stages the user has already cleared.
+      final clearDateByStageNo = <int, int>{};
+      for (final stage in stages) {
+        if (stage.clearDate != null) {
+          clearDateByStageNo[stage.stageNo] = DateTime.parse(
+            stage.clearDate!,
+          ).millisecondsSinceEpoch;
+        }
+      }
+      if (clearDateByStageNo.isNotEmpty) {
+        await _dao.updateClearStatuses(clearDateByStageNo);
+      }
+
+      return stages;
     }
 
     throw Exception('Failed to get stages: ${response.error}');

--- a/lib/src/features/account/account_page.dart
+++ b/lib/src/features/account/account_page.dart
@@ -263,7 +263,7 @@ class _LogoutView extends ConsumerWidget {
       await stageRepository.syncStages();
       ref
         ..invalidate(clearedStageNumbersProvider)
-        ..invalidate(stageCountProvider);
+        ..invalidate(clearedStageCountProvider);
 
       if (context.mounted) {
         Navigator.of(context).pop();

--- a/lib/src/features/account/account_page.dart
+++ b/lib/src/features/account/account_page.dart
@@ -261,8 +261,9 @@ class _LogoutView extends ConsumerWidget {
     try {
       final stageRepository = await ref.read(stageRepositoryProvider.future);
       await stageRepository.syncStages();
-      ref.invalidate(clearedStageNumbersProvider);
-      ref.invalidate(stageCountProvider);
+      ref
+        ..invalidate(clearedStageNumbersProvider)
+        ..invalidate(stageCountProvider);
 
       if (context.mounted) {
         Navigator.of(context).pop();

--- a/lib/src/features/account/account_page.dart
+++ b/lib/src/features/account/account_page.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kyouen_flutter/src/data/repository/stage_repository.dart';
 import 'package:kyouen_flutter/src/features/account/account_service.dart';
 import 'package:kyouen_flutter/src/widgets/common/background_widget.dart';
 import 'package:kyouen_flutter/src/widgets/theme/app_theme.dart';
@@ -163,6 +164,28 @@ class _LogoutView extends ConsumerWidget {
             ),
           ),
           const SizedBox(height: 48),
+          // Sync button
+          SizedBox(
+            height: 56,
+            child: FilledButton.tonal(
+              onPressed: () => _syncStages(context, ref),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.sync, size: 20),
+                  SizedBox(width: 12),
+                  Text(
+                    'クリアデータを同期',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
           // Logout button
           SizedBox(
             height: 56,
@@ -216,6 +239,45 @@ class _LogoutView extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  Future<void> _syncStages(BuildContext context, WidgetRef ref) async {
+    // ignore: unawaited_futures
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => const AlertDialog(
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 16),
+            Text('同期中...'),
+          ],
+        ),
+      ),
+    );
+
+    try {
+      final stageRepository = await ref.read(stageRepositoryProvider.future);
+      await stageRepository.syncStages();
+      ref.invalidate(clearedStageNumbersProvider);
+      ref.invalidate(stageCountProvider);
+
+      if (context.mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('クリアデータを同期しました')),
+        );
+      }
+    } on Exception catch (e) {
+      if (context.mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('同期に失敗しました: $e')),
+        );
+      }
+    }
   }
 
   void _showDeleteAccountDialog(BuildContext context, WidgetRef ref) {

--- a/lib/src/features/account/account_service.dart
+++ b/lib/src/features/account/account_service.dart
@@ -124,11 +124,14 @@ class AccountService extends _$AccountService {
 
     // Sync cleared stages after login; failures are non-fatal.
     try {
-      if (!ref.mounted) return;
+      if (!ref.mounted) {
+        return;
+      }
       final stageRepository = await ref.read(stageRepositoryProvider.future);
       await stageRepository.syncStages();
-      ref.invalidate(clearedStageNumbersProvider);
-      ref.invalidate(stageCountProvider);
+      ref
+        ..invalidate(clearedStageNumbersProvider)
+        ..invalidate(stageCountProvider);
     } on Exception catch (e) {
       logger.w('Sync after login failed (non-fatal): $e');
     }

--- a/lib/src/features/account/account_service.dart
+++ b/lib/src/features/account/account_service.dart
@@ -131,7 +131,7 @@ class AccountService extends _$AccountService {
       await stageRepository.syncStages();
       ref
         ..invalidate(clearedStageNumbersProvider)
-        ..invalidate(stageCountProvider);
+        ..invalidate(clearedStageCountProvider);
     } on Exception catch (e) {
       logger.w('Sync after login failed (non-fatal): $e');
     }

--- a/lib/src/features/account/account_service.dart
+++ b/lib/src/features/account/account_service.dart
@@ -8,13 +8,14 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'account_service.g.dart';
 
-@Riverpod(keepAlive: true)
+@riverpod
 class AccountService extends _$AccountService {
   @override
   void build() {}
 
   Future<void> signInWithTwitter() async {
     final logger = Logger();
+    final link = ref.keepAlive();
     await signOut();
     final twitterProvider = TwitterAuthProvider();
 
@@ -38,11 +39,14 @@ class AccountService extends _$AccountService {
     } on Exception catch (e) {
       logger.e('Twitter sign-in failed: $e');
       rethrow;
+    } finally {
+      link.close();
     }
   }
 
   Future<void> signInWithApple() async {
     final logger = Logger();
+    final link = ref.keepAlive();
     final appleProvider = AppleAuthProvider();
 
     try {
@@ -65,6 +69,8 @@ class AccountService extends _$AccountService {
     } on Exception catch (e) {
       logger.e('Apple sign-in failed: $e');
       rethrow;
+    } finally {
+      link.close();
     }
   }
 

--- a/lib/src/features/account/account_service.dart
+++ b/lib/src/features/account/account_service.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:kyouen_flutter/src/data/api/api_client.dart';
 import 'package:kyouen_flutter/src/data/api/entity/login_request.dart';
+import 'package:kyouen_flutter/src/data/repository/stage_repository.dart';
 import 'package:logger/logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -119,6 +120,17 @@ class AccountService extends _$AccountService {
     } on Exception catch (e) {
       logger.e('Login API call failed: $e');
       rethrow;
+    }
+
+    // Sync cleared stages after login; failures are non-fatal.
+    try {
+      if (!ref.mounted) return;
+      final stageRepository = await ref.read(stageRepositoryProvider.future);
+      await stageRepository.syncStages();
+      ref.invalidate(clearedStageNumbersProvider);
+      ref.invalidate(stageCountProvider);
+    } on Exception catch (e) {
+      logger.w('Sync after login failed (non-fatal): $e');
     }
   }
 }

--- a/lib/src/features/account/account_service.dart
+++ b/lib/src/features/account/account_service.dart
@@ -8,7 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'account_service.g.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 class AccountService extends _$AccountService {
   @override
   void build() {}
@@ -31,6 +31,7 @@ class AccountService extends _$AccountService {
       }
 
       if (!ref.mounted) {
+        logger.w('Ref not mounted after Twitter sign-in');
         return;
       }
       await _callLoginApi(userCredential.user);
@@ -57,6 +58,7 @@ class AccountService extends _$AccountService {
       }
 
       if (!ref.mounted) {
+        logger.w('Ref not mounted after Apple sign-in');
         return;
       }
       await _callLoginApi(userCredential.user);

--- a/lib/src/features/stage/stage_service.dart
+++ b/lib/src/features/stage/stage_service.dart
@@ -49,7 +49,7 @@ Future<List<StageResponse>> fetchStages(Ref ref, {required int page}) async {
       .getStages(startStageNo: ((page - 1) * 10) + 1);
   final apiStages = response.body ?? [];
 
-  // Save all stages to SQLite for future offline access
+  // Save all stages to SQLite, preserving existing clear_flag/clear_date.
   if (apiStages.isNotEmpty) {
     final dao = await ref.watch(tumeKyouenDaoProvider.future);
     final tumeKyouens = apiStages
@@ -65,8 +65,7 @@ Future<List<StageResponse>> fetchStages(Ref ref, {required int page}) async {
         )
         .toList();
 
-    // Insert with REPLACE to handle duplicates
-    await dao.insertAll(tumeKyouens);
+    await dao.insertOrUpdateStages(tumeKyouens);
   }
 
   return apiStages;
@@ -94,7 +93,7 @@ Future<StageResponse> fetchStage(Ref ref, {required int stageNo}) async {
   final stages = await ref.watch(fetchStagesProvider(page: page).future);
   final apiStage = stages[((stageNo - 1) % 10)];
 
-  // Save to SQLite for future use
+  // Save to SQLite for future use, preserving existing clear_flag/clear_date.
   final tumeKyouen = TumeKyouen(
     stageNo: apiStage.stageNo,
     size: apiStage.size,
@@ -104,7 +103,7 @@ Future<StageResponse> fetchStage(Ref ref, {required int stageNo}) async {
     clearDate: 0,
   );
 
-  await dao.insertAll([tumeKyouen]);
+  await dao.insertOrUpdateStages([tumeKyouen]);
 
   return apiStage;
 }

--- a/lib/src/features/stage/stage_service.dart
+++ b/lib/src/features/stage/stage_service.dart
@@ -66,6 +66,19 @@ Future<List<StageResponse>> fetchStages(Ref ref, {required int page}) async {
         .toList();
 
     await dao.insertOrUpdateStages(tumeKyouens);
+
+    // Reflect server-side clear status for stages the user has already cleared.
+    final clearDateByStageNo = <int, int>{};
+    for (final apiStage in apiStages) {
+      if (apiStage.clearDate != null) {
+        clearDateByStageNo[apiStage.stageNo] = DateTime.parse(
+          apiStage.clearDate!,
+        ).millisecondsSinceEpoch;
+      }
+    }
+    if (clearDateByStageNo.isNotEmpty) {
+      await dao.updateClearStatuses(clearDateByStageNo);
+    }
   }
 
   return apiStages;

--- a/lib/src/features/stage/stage_service.dart
+++ b/lib/src/features/stage/stage_service.dart
@@ -78,6 +78,9 @@ Future<List<StageResponse>> fetchStages(Ref ref, {required int page}) async {
     }
     if (clearDateByStageNo.isNotEmpty) {
       await dao.updateClearStatuses(clearDateByStageNo);
+      ref
+        ..invalidate(clearedStageNumbersProvider)
+        ..invalidate(clearedStageCountProvider);
     }
   }
 

--- a/lib/src/features/stage/stage_service.dart
+++ b/lib/src/features/stage/stage_service.dart
@@ -223,8 +223,9 @@ class CurrentStage extends _$CurrentStage {
     final stageRepository = await ref.read(stageRepositoryProvider.future);
     await stageRepository.clearStage(currentStageNo, currentStageState);
 
-    // Invalidate the cleared stages provider to refresh UI
-    ref.invalidate(clearedStageNumbersProvider);
+    ref
+      ..invalidate(clearedStageNumbersProvider)
+      ..invalidate(clearedStageCountProvider);
   }
 }
 

--- a/lib/src/features/title/native_title_page.dart
+++ b/lib/src/features/title/native_title_page.dart
@@ -335,18 +335,15 @@ class _StageProgressDisplay extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final stageCountAsync = ref.watch(stageCountProvider);
+    final clearedAsync = ref.watch(clearedStageCountProvider);
     final totalAsync = ref.watch(totalStageCountProvider);
 
     final total = totalAsync.asData?.value ?? 0;
 
-    return stageCountAsync.when(
+    return clearedAsync.when(
       loading: () => const _ProgressView(cleared: 0, total: 0, isLoading: true),
       error: (_, _) => const SizedBox.shrink(),
-      data: (stageCount) {
-        final cleared = stageCount['clear_count'] ?? 0;
-        return _ProgressView(cleared: cleared, total: total);
-      },
+      data: (cleared) => _ProgressView(cleared: cleared, total: total),
     );
   }
 }

--- a/lib/src/features/title/native_title_page.dart
+++ b/lib/src/features/title/native_title_page.dart
@@ -342,7 +342,7 @@ class _StageProgressDisplay extends ConsumerWidget {
 
     return stageCountAsync.when(
       loading: () => const _ProgressView(cleared: 0, total: 0, isLoading: true),
-      error: (_, __) => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
       data: (stageCount) {
         final cleared = stageCount['clear_count'] ?? 0;
         return _ProgressView(cleared: cleared, total: total);

--- a/lib/src/features/title/native_title_page.dart
+++ b/lib/src/features/title/native_title_page.dart
@@ -335,34 +335,18 @@ class _StageProgressDisplay extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final stageRepositoryAsync = ref.watch(stageRepositoryProvider);
+    final stageCountAsync = ref.watch(stageCountProvider);
     final totalAsync = ref.watch(totalStageCountProvider);
 
     final total = totalAsync.asData?.value ?? 0;
 
-    return stageRepositoryAsync.when(
+    return stageCountAsync.when(
       loading: () => const _ProgressView(cleared: 0, total: 0, isLoading: true),
-      error: (error, stackTrace) => const SizedBox.shrink(),
-      data: (repository) => FutureBuilder<Map<String, int>>(
-        future: repository.getStageCount(),
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
-            return _ProgressView(
-              cleared: 0,
-              total: total,
-              isLoading: total == 0,
-            );
-          }
-          if (snapshot.hasError) {
-            return const SizedBox.shrink();
-          }
-
-          final stageCount = snapshot.data!;
-          final cleared = stageCount['clear_count'] ?? 0;
-
-          return _ProgressView(cleared: cleared, total: total);
-        },
-      ),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (stageCount) {
+        final cleared = stageCount['clear_count'] ?? 0;
+        return _ProgressView(cleared: cleared, total: total);
+      },
     );
   }
 }

--- a/lib/src/features/title/web_title_page.dart
+++ b/lib/src/features/title/web_title_page.dart
@@ -353,7 +353,7 @@ class _WebStageCountDisplay extends ConsumerWidget {
           style: TextStyle(fontSize: 14, color: Colors.white54),
         ),
       ),
-      error: (_, __) => Container(
+      error: (_, _) => Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
         decoration: BoxDecoration(
           color: Colors.white.withValues(alpha: 0.06),

--- a/lib/src/features/title/web_title_page.dart
+++ b/lib/src/features/title/web_title_page.dart
@@ -335,12 +335,12 @@ class _ActivitiesDisplay extends ConsumerWidget {
 class _WebStageCountDisplay extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final stageCountAsync = ref.watch(stageCountProvider);
+    final clearedAsync = ref.watch(clearedStageCountProvider);
     final totalAsync = ref.watch(totalStageCountProvider);
 
     final totalCount = totalAsync.asData?.value ?? 0;
 
-    return stageCountAsync.when(
+    return clearedAsync.when(
       loading: () => Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
         decoration: BoxDecoration(
@@ -367,27 +367,24 @@ class _WebStageCountDisplay extends ConsumerWidget {
           style: TextStyle(fontSize: 14, color: Color(0xFFE53935)),
         ),
       ),
-      data: (stageCount) {
-        final clearedCount = stageCount['clear_count'] ?? 0;
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-          decoration: BoxDecoration(
-            color: AppTheme.accentColor.withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: AppTheme.accentColor.withValues(alpha: 0.4),
-            ),
+      data: (clearedCount) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+        decoration: BoxDecoration(
+          color: AppTheme.accentColor.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: AppTheme.accentColor.withValues(alpha: 0.4),
           ),
-          child: Text(
-            'クリアステージ数: $clearedCount / $totalCount',
-            style: const TextStyle(
-              fontSize: 14,
-              color: AppTheme.accentColor,
-              fontWeight: FontWeight.w500,
-            ),
+        ),
+        child: Text(
+          'クリアステージ数: $clearedCount / $totalCount',
+          style: const TextStyle(
+            fontSize: 14,
+            color: AppTheme.accentColor,
+            fontWeight: FontWeight.w500,
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/title/web_title_page.dart
+++ b/lib/src/features/title/web_title_page.dart
@@ -335,12 +335,12 @@ class _ActivitiesDisplay extends ConsumerWidget {
 class _WebStageCountDisplay extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final stageRepositoryAsync = ref.watch(stageRepositoryProvider);
+    final stageCountAsync = ref.watch(stageCountProvider);
     final totalAsync = ref.watch(totalStageCountProvider);
 
     final totalCount = totalAsync.asData?.value ?? 0;
 
-    return stageRepositoryAsync.when(
+    return stageCountAsync.when(
       loading: () => Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
         decoration: BoxDecoration(
@@ -353,7 +353,7 @@ class _WebStageCountDisplay extends ConsumerWidget {
           style: TextStyle(fontSize: 14, color: Colors.white54),
         ),
       ),
-      error: (error, _) => Container(
+      error: (_, __) => Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
         decoration: BoxDecoration(
           color: Colors.white.withValues(alpha: 0.06),
@@ -367,79 +367,27 @@ class _WebStageCountDisplay extends ConsumerWidget {
           style: TextStyle(fontSize: 14, color: Color(0xFFE53935)),
         ),
       ),
-      data: (repository) => FutureBuilder<Map<String, int>>(
-        future: repository.getStageCount(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting &&
-              totalCount == 0) {
-            return Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 20,
-                vertical: 10,
-              ),
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.10),
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.08),
-                ),
-              ),
-              child: const Text(
-                'ステージ情報を読み込み中...',
-                style: TextStyle(fontSize: 14, color: Colors.white54),
-              ),
-            );
-          }
-
-          if (snapshot.hasError) {
-            return Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 20,
-                vertical: 10,
-              ),
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.06),
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: const Color(0xFFE53935).withValues(alpha: 0.4),
-                ),
-              ),
-              child: const Text(
-                'ステージ情報取得エラー',
-                style: TextStyle(
-                  fontSize: 14,
-                  color: Color(0xFFE53935),
-                ),
-              ),
-            );
-          }
-
-          final stageCount = snapshot.data ?? {};
-          final clearedCount = stageCount['clear_count'] ?? 0;
-
-          return Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 20,
-              vertical: 10,
+      data: (stageCount) {
+        final clearedCount = stageCount['clear_count'] ?? 0;
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+          decoration: BoxDecoration(
+            color: AppTheme.accentColor.withValues(alpha: 0.15),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: AppTheme.accentColor.withValues(alpha: 0.4),
             ),
-            decoration: BoxDecoration(
-              color: AppTheme.accentColor.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: AppTheme.accentColor.withValues(alpha: 0.4),
-              ),
+          ),
+          child: Text(
+            'クリアステージ数: $clearedCount / $totalCount',
+            style: const TextStyle(
+              fontSize: 14,
+              color: AppTheme.accentColor,
+              fontWeight: FontWeight.w500,
             ),
-            child: Text(
-              'クリアステージ数: $clearedCount / $totalCount',
-              style: const TextStyle(
-                fontSize: 14,
-                color: AppTheme.accentColor,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/features/title/title_page_test.dart
+++ b/test/features/title/title_page_test.dart
@@ -14,12 +14,6 @@ class MockTotalStageCount extends TotalStageCount {
 // Mock for testing
 class MockStageRepository implements StageRepository {
   @override
-  Future<Map<String, int>> getStageCount() async {
-    // Return mock data for testing
-    return {'count': 10, 'clear_count': 3};
-  }
-
-  @override
   Future<void> markStageCleared(int stageNo) async {
     // Mock implementation - do nothing
   }

--- a/test/features/title/title_page_test.dart
+++ b/test/features/title/title_page_test.dart
@@ -26,8 +26,12 @@ class MockStageRepository implements StageRepository {
 
   @override
   Future<bool> isStageCleared(int stageNo) async {
-    // Mock implementation - return false
     return false;
+  }
+
+  @override
+  Future<int> getClearedCount() async {
+    return 3;
   }
 
   // Add other required methods as no-op implementations


### PR DESCRIPTION
## 概要

- **バグ修正**: `insertAll`が`REPLACE`戦略を使用していたため、APIからステージを取得するたびに`clear_flag`が0にリセットされていた問題を修正。`insertOrUpdateStages`に変更し、既存レコードの`clear_flag`/`clear_date`を保持するようにした
- **フェッチ時のサーバークリア情報反映**: `StageResponse`に`clear_date`フィールドを追加。`fetchStages`および`StageRepository.getStages`でフェッチ後にサーバー側のクリア情報をローカルDBへ反映するようにした
- **オフライン対応のclearStage**: API呼び出しをtry-catchで囲み、オフライン時でもローカルDBは必ず更新されるようにした（クリア情報は次回sync時にサーバーへ送信される）
- **syncStagesの改善**: `updateClearStatuses` DAOメソッドによる一括更新に変更。サーバーのレスポンスを正とし、返却されたクリア数を`SharedPreferences`に保存するようにした
- **ログイン後の自動sync**: `AccountService._callLoginApi`でログイン成功後に`syncStages`を自動呼び出し（失敗してもnon-fatalとして扱う）、ローカルDBにサーバー側のクリア情報を即時反映するようにした
- **keepAlive修正**: Twitter/Apple認証の非同期処理中に`ref.keepAlive()`を保持し、認証途中でプロバイダーが破棄される問題を修正した
- **ClearedStageCountService**: `SharedPreferences`でクリア済みステージ数を管理する新サービスを追加。初回アクセス時はSQLiteの値でシードするため、アプリ更新後も既存ユーザーが正しい値を見られるようにした
- **clearedStageCountProvider**: `ClearedStageCountService`をバックエンドとする新Riverpodプロバイダーを追加。クリアまたはsync後にinvalidateされるため、進捗バーがリアクティブに更新される
- **UIの簡略化**: ネイティブの`_StageProgressDisplay`とWebの`_WebStageCountDisplay`が`clearedStageCountProvider`を直接watchするように変更し、`FutureBuilder` + `getStageCount()`の入れ子構造を除去した
- **同期ボタンのUX改善**: `FilledButton.tonal`に変更、ラベルを「クリアデータを同期」に改名、sync中にProgressDialogを表示するようにした

https://claude.ai/code/session_01Qr22tD1H8QrtvnYSobwsLW