### PR TITLE
fix: ステージクリアのAPI呼び出しをfire-and-forgetにしてダイアログ遅延を解消

### DIFF
--- a/lib/src/data/repository/stage_repository.dart
+++ b/lib/src/data/repository/stage_repository.dart
@@ -105,21 +105,21 @@ class StageRepository {
   Future<void> clearStage(int stageNo, String userStage) async {
     final now = DateTime.now().millisecondsSinceEpoch;
 
-    try {
-      final clearStageRequest = ClearStage(
-        stage: userStage,
-        clearDate: DateTime.now().toUtc().toIso8601String(),
-      );
-      await _apiClient.clearStage(stageNo, clearStageRequest);
-    } on Exception catch (_) {
-      // Offline or API error — the clear is stored locally and will sync later.
-    }
-
+    // Local DB operations first so the caller is not blocked by the network.
     final existing = await _dao.findStage(stageNo);
     if (existing?.clearFlag != TumeKyouen.cleared) {
       await _clearedCountService.increment();
     }
     await _dao.clearStage(stageNo, now);
+
+    // Fire-and-forget: sync to server without blocking the UI.
+    final clearStageRequest = ClearStage(
+      stage: userStage,
+      clearDate: DateTime.now().toUtc().toIso8601String(),
+    );
+    _apiClient.clearStage(stageNo, clearStageRequest).catchError((_) {
+      // Offline or API error — the clear is stored locally and will sync later.
+    });
   }
 
   /// Sends locally cleared stages to server and updates local DB with the


### PR DESCRIPTION
clearStage()でローカルDB更新を先に完了させ、APIへの同期はバックグラウンドで
実行することで、アニメーション終了後すぐにダイアログを表示できるようにした。

https://claude.ai/code/session_01SHhrmoQe3aitqiKLqJMwNY