### PR TITLE
fix: catchErrorの型エラーをunawaitedで修正

### DIFF
--- a/lib/src/data/repository/stage_repository.dart
+++ b/lib/src/data/repository/stage_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:kyouen_flutter/src/data/api/api_client.dart';
 import 'package:kyouen_flutter/src/data/api/entity/clear_stage.dart';
 import 'package:kyouen_flutter/src/data/api/entity/cleared_stage.dart';
@@ -117,9 +119,11 @@ class StageRepository {
       stage: userStage,
       clearDate: DateTime.now().toUtc().toIso8601String(),
     );
-    _apiClient.clearStage(stageNo, clearStageRequest).catchError((_) {
-      // Offline or API error — the clear is stored locally and will sync later.
-    });
+    unawaited(
+      _apiClient
+          .clearStage(stageNo, clearStageRequest)
+          .then<void>((_) {}, onError: (_) {}),
+    );
   }
 
   /// Sends locally cleared stages to server and updates local DB with the


### PR DESCRIPTION
## 問題

PR #88 のマージ後、CIの「Analyze project source」で1件のエラーが発生。

原因は `catchError((_) {})` のコールバックが `Future<Response<void>>` に対して正しい型を返さないこと。また、`.catchError()` の戻り値の Future が awaited でないため `unawaited_futures` lint にも該当する。

## 修正

- `dart:async` の `unawaited()` を使用して意図的な非待機であることを明示
- `.then<void>((_) {}, onError: (_) {})` で型を `Future<void>` に変換してから渡すことで型エラーを解消

```dart
// before
_apiClient.clearStage(stageNo, clearStageRequest).catchError((_) {});

// after
unawaited(
  _apiClient
      .clearStage(stageNo, clearStageRequest)
      .then<void>((_) {}, onError: (_) {}),
);
```

https://claude.ai/code/session_01SHhrmoQe3aitqiKLqJMwNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHhrmoQe3aitqiKLqJMwNY)_